### PR TITLE
Create ChatRoom Pydantic models

### DIFF
--- a/backend/app/models/chat_room.py
+++ b/backend/app/models/chat_room.py
@@ -1,0 +1,54 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+# Pydantic model for API validation
+class ChatRoomCreate(BaseModel):
+    name: str
+
+    class Config:
+        orm_mode = True
+        from_attributes = True
+        allow_population_by_field_name = True
+
+
+class ChatRoomUpdate(BaseModel):
+    name: str | None = None
+
+    class Config:
+        orm_mode = True
+        from_attributes = True
+        allow_population_by_field_name = True
+
+
+class ChatRoomGet(BaseModel):
+    room_id: uuid.UUID
+    name: str
+    creator_id: uuid.UUID
+    created_at: datetime
+
+
+# sqlalchemy model for database
+class ChatRoom(Base):
+    __tablename__ = "chat_rooms"
+
+    room_id = Column(
+        UUID(as_uuid=True), primary_key=True, index=True, default=uuid.uuid4
+    )
+    name = Column(String(100), nullable=False)
+    creator_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.user_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )


### PR DESCRIPTION
This pull request introduces a new `ChatRoom` model in the `backend/app/models/chat_room.py` file. The changes include both SQLAlchemy models for database interactions and Pydantic models for API validation, enabling the creation, update, and retrieval of chat room data.

### Additions to support chat room functionality:

* **Pydantic models for API validation**:
  - Added `ChatRoomCreate`, `ChatRoomUpdate`, and `ChatRoomGet` models to handle API input and output validation for chat rooms. These models include fields like `name`, `room_id`, `creator_id`, and `created_at`, with configurations for ORM compatibility and attribute population.

* **SQLAlchemy model for database**:
  - Introduced the `ChatRoom` model with fields such as `room_id`, `name`, `creator_id`, and `created_at`. This model defines the schema for the `chat_rooms` database table, including relationships and constraints (e.g., foreign key linking `creator_id` to the `users` table).