### PR TITLE
bug: remove profile_picture_url from user registration and update related services

### DIFF
--- a/backend/realtime_messaging/models/auth.py
+++ b/backend/realtime_messaging/models/auth.py
@@ -61,7 +61,6 @@ class RegisterRequest(BaseModel):
     username: str
     password: str
     display_name: str | None = None
-    profile_picture_url: str | None = None
 
     @field_validator("username")
     @classmethod

--- a/backend/realtime_messaging/routes/auth.py
+++ b/backend/realtime_messaging/routes/auth.py
@@ -45,7 +45,6 @@ async def register(
             username=register_data.username,
             password=register_data.password,
             display_name=register_data.display_name,
-            profile_picture_url=register_data.profile_picture_url,
         )
 
         # Register the user

--- a/backend/realtime_messaging/routes/rooms.py
+++ b/backend/realtime_messaging/routes/rooms.py
@@ -71,7 +71,7 @@ async def get_user_rooms(
     """Get all rooms that the current user is a participant in."""
     try:
         rooms = await RoomService.get_user_rooms(session, current_user.user_id)
-        return rooms
+        return [ChatRoomGet.model_validate(room) for room in rooms]
 
     except Exception as e:
         raise HTTPException(

--- a/backend/realtime_messaging/routes/rooms.py
+++ b/backend/realtime_messaging/routes/rooms.py
@@ -64,14 +64,14 @@ async def create_room(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
-@router.get("/", response_model=List[ChatRoomGet])
+@router.get("/", response_model=List[ChatRoomGet], status_code=status.HTTP_200_OK)
 async def get_user_rooms(
     current_user: CurrentUser, session: AsyncSession = Depends(get_db)
 ) -> List[ChatRoomGet]:
     """Get all rooms that the current user is a participant in."""
     try:
         rooms = await RoomService.get_user_rooms(session, current_user.user_id)
-        return [ChatRoomGet.model_validate(room) for room in rooms]
+        return rooms
 
     except Exception as e:
         raise HTTPException(

--- a/backend/realtime_messaging/services/room_service.py
+++ b/backend/realtime_messaging/services/room_service.py
@@ -103,8 +103,8 @@ class RoomService:
             .where(RoomParticipant.user_id == user_id)
             .order_by(ChatRoom.created_at.desc())
         )
-        rooms = await session.execute(stmt)
-        return rooms.scalars().all()
+        result = await session.execute(stmt)
+        return result.scalars().all()
 
     @staticmethod
     async def is_user_participant(

--- a/backend/realtime_messaging/services/room_service.py
+++ b/backend/realtime_messaging/services/room_service.py
@@ -103,8 +103,8 @@ class RoomService:
             .where(RoomParticipant.user_id == user_id)
             .order_by(ChatRoom.created_at.desc())
         )
-        result = await session.execute(stmt)
-        return list(result.scalars().all())
+        rooms = await session.execute(stmt)
+        return rooms.scalars().all()
 
     @staticmethod
     async def is_user_participant(

--- a/backend/realtime_messaging/services/user_service.py
+++ b/backend/realtime_messaging/services/user_service.py
@@ -39,7 +39,6 @@ class UserService:
                 username=user_data.username,
                 hashed_password=hashed_password,
                 display_name=user_data.display_name,
-                profile_picture_url=user_data.profile_picture_url,
             )
 
             # Add to session and commit
@@ -92,8 +91,6 @@ class UserService:
             user.username = user_data.username
         if user_data.display_name is not None:
             user.display_name = user_data.display_name
-        if user_data.profile_picture_url is not None:
-            user.profile_picture_url = user_data.profile_picture_url
 
         try:
             await session.commit()
@@ -144,14 +141,6 @@ class UserService:
             if len(profile_data.display_name) > 50:
                 raise ValueError("Display name must be 50 characters or less")
 
-        # Validate profile picture URL if provided
-        if profile_data.profile_picture_url is not None:
-            if (
-                profile_data.profile_picture_url
-                and len(profile_data.profile_picture_url) > 255
-            ):
-                raise ValueError("Profile picture URL must be 255 characters or less")
-
         # Validate username if provided
         if profile_data.username is not None:
             if len(profile_data.username.strip()) == 0:
@@ -171,8 +160,6 @@ class UserService:
             user.username = profile_data.username.strip()
         if profile_data.display_name is not None:
             user.display_name = profile_data.display_name.strip()
-        if profile_data.profile_picture_url is not None:
-            user.profile_picture_url = profile_data.profile_picture_url
 
         try:
             await session.commit()


### PR DESCRIPTION
This pull request removes support for the `profile_picture_url` field from user registration, user creation, and user profile updates in the realtime messaging backend. The changes ensure that the `profile_picture_url` is no longer accepted, validated, or processed across the API endpoints and service layers.

**User data model and API changes:**

* Removed the `profile_picture_url` field from the `RegisterRequest` model in `auth.py`, so new users can no longer provide a profile picture URL during registration.
* Updated the registration endpoint in `auth.py` to stop accepting and passing the `profile_picture_url` field.

**Service layer changes:**

* Removed handling of `profile_picture_url` from user creation and update logic in `user_service.py`, including validation and assignment during profile updates. [[1]](diffhunk://#diff-4d03bbb176b0295c1c23a7722a20b26b67106e7eac7a0eda8d8f7024d3c6bd70L42) [[2]](diffhunk://#diff-4d03bbb176b0295c1c23a7722a20b26b67106e7eac7a0eda8d8f7024d3c6bd70L95-L96) [[3]](diffhunk://#diff-4d03bbb176b0295c1c23a7722a20b26b67106e7eac7a0eda8d8f7024d3c6bd70L147-L154) [[4]](diffhunk://#diff-4d03bbb176b0295c1c23a7722a20b26b67106e7eac7a0eda8d8f7024d3c6bd70L174-L175)

**Room retrieval endpoint improvements:**

* Changed the response logic in `rooms.py` and `room_service.py` for getting user rooms to return the list of rooms directly, and explicitly set the HTTP status code to 200 OK for clarity. [[1]](diffhunk://#diff-9442ed7e7b4e7dcbff16a199f416b8edb7141a4f7cc7f80e8ec3bfb0f9649d0eL67-R74) [[2]](diffhunk://#diff-d842ef0ef6a94fd7289808095e9f3fc6040f8a46a326fff21803ee59d0123ac8L106-R107)