### PR TITLE
feat: add room preview endpoint and model for join decision

### DIFF
--- a/backend/realtime_messaging/models/chat_room.py
+++ b/backend/realtime_messaging/models/chat_room.py
@@ -34,6 +34,21 @@ class PublicRoomSummary(BaseModel):
     creator_username: str
 
 
+class RoomPreview(BaseModel):
+    """Detailed preview for join decision."""
+
+    room_id: uuid.UUID
+    name: str
+    description: str | None
+    creator_username: str
+    participant_count: int
+    max_participants: int | None
+    avatar_url: str | None
+    created_at: datetime
+    is_user_participant: bool
+    can_join: bool
+
+
 # Shared validation methods
 class ChatRoomValidators:
     @staticmethod

--- a/backend/realtime_messaging/services/common.py
+++ b/backend/realtime_messaging/services/common.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel, Field
 
 
-
 class PaginationParams(BaseModel):
     limit: int = Field(20, le=50, description="Number of data items to return")
     offset: int = Field(0, ge=0, description="Number of data items to skip")


### PR DESCRIPTION
This pull request introduces a new feature that allows users to retrieve a detailed preview of a chat room before deciding to join. It adds a new API endpoint and supporting model, along with the necessary service logic to provide information such as participant count, join eligibility, and whether the user is already a participant.

### New Room Preview Feature

* Added the `RoomPreview` Pydantic model to `chat_room.py`, containing fields for room metadata, participant info, and join eligibility.
* Implemented the `get_room_preview` method in `RoomService` to fetch detailed room information, including participant count and join status, for a specific user.

### API Changes

* Added a new endpoint `GET /{room_id}/preview` in `routes/rooms.py` that returns a `RoomPreview` for the specified room and user.
* Updated import statements in `routes/rooms.py` and `room_service.py` to include the new `RoomPreview` model. [[1]](diffhunk://#diff-9442ed7e7b4e7dcbff16a199f416b8edb7141a4f7cc7f80e8ec3bfb0f9649d0eR14) [[2]](diffhunk://#diff-d842ef0ef6a94fd7289808095e9f3fc6040f8a46a326fff21803ee59d0123ac8R18)

### Minor Code Cleanup

* Removed an unnecessary blank line in `services/common.py`.