### PR TITLE
feature: enhance update fields for update room endpoint

### DIFF
--- a/backend/realtime_messaging/messages.py
+++ b/backend/realtime_messaging/messages.py
@@ -1,3 +1,4 @@
 ERROR_NOT_PARTICIPANT = "You must be a participant to view room details"
 ERROR_ROOM_NOT_FOUND = "Room not found"
 FAILED_TO_RETRIEVE_PUBLIC_ROOMS = "Failed to retrieve public rooms"
+ERROR_ONLY_CREATOR_CAN_UPDATE = "Only room creator can update room details"

--- a/backend/realtime_messaging/models/chat_room.py
+++ b/backend/realtime_messaging/models/chat_room.py
@@ -24,7 +24,11 @@ DEFAULT_ROOM_SETTINGS = {
 class RoomWithDetails(BaseModel):
     room_id: uuid.UUID
     name: str
-    creator_id: uuid.UUID
+    description: str | None
+    is_private: bool
+    max_participants: int | None
+    avatar_url: str | None
+    creator_name: str
     created_at: str
     participant_count: int
 
@@ -93,6 +97,14 @@ class ChatRoomValidators:
             value = value.strip()
             if len(value) == 0:
                 return None
+        return value
+
+    @staticmethod
+    def validate_room_name(value):
+        if value is not None:
+            value = value.strip()
+            if len(value) == 0:
+                raise ValueError("Room name cannot be empty")
         return value
 
 
@@ -196,6 +208,11 @@ class ChatRoomUpdateBase(BaseModel):
     @classmethod
     def validate_settings(cls, value):
         return ChatRoomValidators.validate_settings_structure(value)
+
+    @field_validator("name")
+    @classmethod
+    def validate_room_name(cls, value):
+        return ChatRoomValidators.validate_room_name(value)
 
 
 class ChatRoomUpdate(ChatRoomUpdateBase):

--- a/backend/realtime_messaging/routes/rooms.py
+++ b/backend/realtime_messaging/routes/rooms.py
@@ -144,46 +144,21 @@ async def get_room_details(
     return room
 
 
-@router.put("/{room_id}", response_model=ChatRoomGet)
+@router.patch("/{room_id}")
 async def update_room(
     room_id: UUIDType,
     room_data: ChatRoomUpdate,
     current_user: CurrentUser,
     session: AsyncSession = Depends(get_db),
-) -> ChatRoomGet:
+) -> None:
     """Update room details (only room creator can update)."""
-    try:
-        if room_data.name is not None:
-            if len(room_data.name.strip()) == 0:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Room name cannot be empty",
-                )
-
-            if len(room_data.name.strip()) > 100:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Room name must be 100 characters or less",
-                )
-
-        updated_room = await RoomService.update_room(
-            session,
-            room_id,
-            current_user.user_id,
-            room_data.model_dump(exclude_unset=True),
-        )
-
-        if not updated_room:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Room not found"
-            )
-
-        return ChatRoomGet.model_validate(updated_room)
-
-    except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(e))
-    except HTTPException:
-        raise
+    _ = await RoomService.update_room(
+        session,
+        room_id,
+        current_user.user_id,
+        room_data.model_dump(exclude_unset=True),
+    )
+    return None
 
 
 @router.delete("/{room_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/realtime_messaging/services/room_service.py
+++ b/backend/realtime_messaging/services/room_service.py
@@ -499,7 +499,7 @@ class RoomService:
 
             return room
 
-        except Exception as e:
+        except IntegrityError as e:
             await session.rollback()
             logger.error(f"Error updating room: {str(e)}")
             raise InternalServerError("Failed to update room due to database error")


### PR DESCRIPTION
This pull request updates the chat room update functionality to improve validation, error handling, and the data returned for room details. The main themes are stricter validation and permissions, improved API responses, and enhanced data returned for room details.

**Validation and Permissions:**
- Added a new validation to ensure room names cannot be empty, both at the model level (`ChatRoomValidators` and Pydantic validators) and in the update logic. [[1]](diffhunk://#diff-6290c8cc9d91f8aa7f163c0c8d637d71c5b820c41f668457c84c9fadda28ff1aR102-R109) [[2]](diffhunk://#diff-6290c8cc9d91f8aa7f163c0c8d637d71c5b820c41f668457c84c9fadda28ff1aR212-R216)
- Enforced that only the room creator can update room details, with a clear error message defined and used. [[1]](diffhunk://#diff-c5d71b58efef102c605131e8dd51d20af39a7e804b14a0792b881dd133fc0109R4) [[2]](diffhunk://#diff-d842ef0ef6a94fd7289808095e9f3fc6040f8a46a326fff21803ee59d0123ac8L466-R505)

**API and Data Model Changes:**
- Changed the `update_room` endpoint from PUT to PATCH, and updated its response to return no content instead of the updated room.
- Updated the `RoomWithDetails` model and the data returned from `get_room_with_participant_count` to include more descriptive fields (description, privacy, avatar, max participants, and creator name) instead of just the creator ID. [[1]](diffhunk://#diff-6290c8cc9d91f8aa7f163c0c8d637d71c5b820c41f668457c84c9fadda28ff1aL27-R31) [[2]](diffhunk://#diff-d842ef0ef6a94fd7289808095e9f3fc6040f8a46a326fff21803ee59d0123ac8R447-R459)

**Error Handling Improvements:**
- Improved error handling in `RoomService.update_room` by raising specific errors for not found and permission issues, and logging database errors with a generic internal server error message.