### PR TITLE
feat: update room participants retrieval to enforce participant check

### DIFF
--- a/backend/realtime_messaging/routes/rooms.py
+++ b/backend/realtime_messaging/routes/rooms.py
@@ -262,38 +262,41 @@ async def get_room_participants(
     session: AsyncSession = Depends(get_db),
 ) -> List[RoomParticipant]:
     """Get all participants in a room."""
-    try:
-        # Check if user is a participant
-        is_participant = await RoomService.is_user_participant(
-            session, room_id, current_user.user_id
-        )
+    # try:
+    participants = await RoomService.get_room_participants(
+        session, room_id, current_user.user_id
+    )
+    # Check if user is a participant
+    # is_participant = await RoomService.is_user_participant(
+    #     session, room_id, current_user.user_id
+    # )
 
-        if not is_participant:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You must be a participant to view room participants",
-            )
+    #     if not is_participant:
+    #         raise HTTPException(
+    #             status_code=status.HTTP_403_FORBIDDEN,
+    #             detail="You must be a participant to view room participants",
+    #         )
 
-        participants_data = await RoomService.get_room_participants(session, room_id)
+    #     participants_data = await RoomService.get_room_participants(session, room_id)
 
-        participants = []
-        for participant in participants_data:
-            participants.append(
-                RoomParticipant(
-                    user_id=UUIDType(participant["user_id"]),
-                    username=participant["username"],
-                    display_name=participant["display_name"],
-                    profile_picture_url=participant["profile_picture_url"],
-                    joined_at=participant["joined_at"],
-                )
-            )
+    #     participants = []
+    #     for participant in participants_data:
+    #         participants.append(
+    #             RoomParticipant(
+    #                 user_id=UUIDType(participant["user_id"]),
+    #                 username=participant["username"],
+    #                 display_name=participant["display_name"],
+    #                 profile_picture_url=participant["profile_picture_url"],
+    #                 joined_at=participant["joined_at"],
+    #             )
+    #         )
 
-        return participants
+    #     return participants
 
-    except HTTPException:
-        raise
-    except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve room participants",
-        )
+    # except HTTPException:
+    #     raise
+    # except Exception:
+    #     raise HTTPException(
+    #         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    #         detail="Failed to retrieve room participants",
+    #     )

--- a/backend/realtime_messaging/services/room_service.py
+++ b/backend/realtime_messaging/services/room_service.py
@@ -328,9 +328,22 @@ class RoomService:
 
     @staticmethod
     async def get_room_participants(
-        session: AsyncSession, room_id: UUIDType, use_cache: bool = True
+        session: AsyncSession,
+        room_id: UUIDType,
+        user_id: UUIDType,
+        use_cache: bool = True,
     ) -> List[dict]:
         """Get all participants in a room with their user details."""
+        room = await RoomService.get_room(session, room_id)
+        if not room:
+            raise NotFoundError(detail=msg.ERROR_ROOM_NOT_FOUND)
+
+        is_participant = await RoomService.is_user_participant(
+            session, room_id, user_id
+        )
+        if not is_participant:
+            raise ForbiddenError(detail=msg.ERROR_NOT_PARTICIPANT)
+
         cache_key = f"room_participants:{room_id}"
 
         # Try to get from cache first


### PR DESCRIPTION
This pull request refactors how room participants are retrieved and how access control is enforced. The main change is moving the logic for checking if a user is a room participant from the API route handler (`rooms.py`) into the service layer (`room_service.py`). This centralizes the access control logic and simplifies the route handler code.

Refactoring and access control improvements:

* Moved the participant access check into the `RoomService.get_room_participants` method, so the service now raises a `ForbiddenError` if the requesting user is not a participant, instead of handling this in the API route.
* Simplified the `get_room_participants` route handler in `rooms.py` by removing redundant error handling and participant transformation logic, relying on the service layer to handle access control and data retrieval.